### PR TITLE
middleware.Cancel

### DIFF
--- a/middleware/cancel.go
+++ b/middleware/cancel.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/pressly/chi"
+	"golang.org/x/net/context"
+)
+
+// Cancel is a middleware that cancels ctx when the underlying handlers
+// return. It enforces any running goroutines (or ctxhttp clients)
+// created down the chain and listening on ctx.Done() channel to stop
+// immediately. Useful for preventing leaks on synchronous operations.
+// It forces to use context.Background() instead of ctx for all
+// goroutines that should live even after the request is processed.
+func Cancel(next chi.Handler) chi.Handler {
+	fn := func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		next.ServeHTTPC(ctx, w, r)
+	}
+	return chi.HandlerFunc(fn)
+}

--- a/middleware/closenotify.go
+++ b/middleware/closenotify.go
@@ -22,11 +22,17 @@ func CloseNotify(next chi.Handler) chi.Handler {
 		}
 
 		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+
+		done := make(chan struct{}, 0)
+		defer func() {
+			close(done)
+		}()
 
 		go func() {
 			select {
 			case <-ctx.Done():
+				return
+			case <-done:
 				return
 			case <-cn.CloseNotify():
 				w.WriteHeader(StatusClientClosedRequest)

--- a/middleware/timeout.go
+++ b/middleware/timeout.go
@@ -14,9 +14,8 @@ const StatusServerTimeout = 504
 func Timeout(timeout time.Duration) func(next chi.Handler) chi.Handler {
 	return func(next chi.Handler) chi.Handler {
 		fn := func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-			ctx, cancel := context.WithTimeout(ctx, timeout)
+			ctx, _ = context.WithTimeout(ctx, timeout)
 			defer func() {
-				cancel()
 				if ctx.Err() == context.DeadlineExceeded {
 					w.WriteHeader(StatusServerTimeout)
 				}


### PR DESCRIPTION
Something for consideration:

`middleware.Timeout()` and `middleware.CloseNotify` don't need to `cancel()` the context when the underlying handlers return. We might want to use explicit `middleware.Cancel` instead.

This way, all handlers would have `context.Background()` as a base context and it'd be up to developers to specify when the "context flow" ends. Timeout should only cancel underlying contexts on timeout. CloseNotify should only cancel underlying contexts on `<-w.CloseNotify()`. Explicit over magic.

If we wanted to have strict boundaries for context lifetime in the handler chain, we'd need to use `context.WithCancel()` instead of `context.Background()` in [mux.ServeHTTPC()](https://github.com/pressly/chi/blob/6cdb0fa9e298c912a8a9382e461066d2fa5fc36e/mux.go#L184).