### PR TITLE
Support custom Not Found handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ See discussions:
   * Trailing slash?
   * Case insensitive paths?
   * GET for HEAD requests (auto fallback)?
-* Register not found handler
+* Register not found handler for mounted routers?
 * Register error handler (500's)
 * HTTP2 example
   * both http 1.1 and http2 automatically.. just turn it on :)

--- a/chi.go
+++ b/chi.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NewRouter() *Mux {
-	return &Mux{}
+	return &Mux{notFound: http.NotFound}
 }
 
 type Router interface {

--- a/mux.go
+++ b/mux.go
@@ -13,7 +13,7 @@ type Mux struct {
 	routes      map[methodTyp]*tree
 
 	notFound http.HandlerFunc
-	
+
 	// can add rules here for how the mux should work..
 	// ie. slashes, case insensitive, 500 error handler etc.. like httprouter
 }
@@ -109,9 +109,9 @@ func (mx *Mux) Options(pattern string, handlers ...interface{}) {
 	mx.handle(mOPTIONS, pattern, handlers...)
 }
 
-// NotFoundHandler sets a custom handler for the case when no routes matched
+// NotFound sets a custom handler for the case when no routes matched
 // the given URL
-func (mx *Mux) NotFoundHandler(handler http.HandlerFunc) {
+func (mx *Mux) NotFound(handler http.HandlerFunc) {
 	mx.notFound = handler
 }
 

--- a/mux.go
+++ b/mux.go
@@ -12,8 +12,10 @@ type Mux struct {
 	middlewares []interface{}
 	routes      map[methodTyp]*tree
 
+	notFound http.HandlerFunc
+	
 	// can add rules here for how the mux should work..
-	// ie. slashes, case insensitive, notfound handler etc.. like httprouter
+	// ie. slashes, case insensitive, 500 error handler etc.. like httprouter
 }
 
 type methodTyp int
@@ -107,6 +109,12 @@ func (mx *Mux) Options(pattern string, handlers ...interface{}) {
 	mx.handle(mOPTIONS, pattern, handlers...)
 }
 
+// NotFoundHandler sets a custom handler for the case when no routes matched
+// the given URL
+func (mx *Mux) NotFoundHandler(handler http.HandlerFunc) {
+	mx.notFound = handler
+}
+
 func (mx *Mux) handle(method methodTyp, pattern string, handlers ...interface{}) {
 	// Build handler from middleware stack, inline middlewares and handler
 	h := chain(mx.middlewares, handlers...)
@@ -198,8 +206,9 @@ func (mx *Mux) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Re
 	cxh, err = routes.Find(path, params)
 	_ = err // ..
 
+	// No route found
 	if cxh == nil {
-		http.NotFound(w, r)
+		mx.notFound(w, r)
 		return
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -405,8 +405,8 @@ func TestMux(t *testing.T) {
 	}
 
 	// Custom NotFound handler
-	m.NotFoundHandler(func(rw http.ResponseWriter, r *http.Request) {
-		rw.WriteHeader(200)
+	m.NotFound(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
 	})
 
 	resp, err = http.Get(ts.URL + "/NotFound")
@@ -419,5 +419,4 @@ func TestMux(t *testing.T) {
 		t.Error("expecting custom NotFound handler when it is set")
 	}
 
-	
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -393,4 +393,31 @@ func TestMux(t *testing.T) {
 		t.Error("expecting response body: 'catchall'")
 	}
 
+	// Default NotFound error
+	resp, err = http.Get(ts.URL + "/NotFound")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Error("expecting default NotFound error when custom NotFound handler is not set")
+	}
+
+	// Custom NotFound handler
+	m.NotFoundHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(200)
+	}))
+
+	resp, err = http.Get(ts.URL + "/NotFound")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Error("expecting custom NotFound handler when it is set")
+	}
+
+	
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -405,9 +405,9 @@ func TestMux(t *testing.T) {
 	}
 
 	// Custom NotFound handler
-	m.NotFoundHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	m.NotFoundHandler(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(200)
-	}))
+	})
 
 	resp, err = http.Get(ts.URL + "/NotFound")
 	if err != nil {


### PR DESCRIPTION
Basic support for custom NotFound handler. Custom handler is set via  NotFoundHandler method:

```Go
m = chi.NewRouter()
m.NotFoundHandler(func(rw http.ResponseWriter, r *http.Request) {
   rw.WriteHeader(200)
})

```
It is yet to decide how this will work for additional mounted routers.