### PR TITLE
Fixed panics on empty paths

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -111,6 +111,9 @@ func (mx *Mux) handle(method methodTyp, pattern string, handlers ...interface{})
 	// Build handler from middleware stack, inline middlewares and handler
 	h := chain(mx.middlewares, handlers...)
 
+	if len(pattern) == 0 {
+		pattern = "/"
+	}
 	if pattern[0] != '/' {
 		panic("pattern must begin with a /") // TODO: is goji like this too?
 	}

--- a/mux_test.go
+++ b/mux_test.go
@@ -103,7 +103,7 @@ func TestMux(t *testing.T) {
 	m.Use(usermw)
 	m.Use(exmw)
 	m.Use(logmw)
-	m.Get("/", cxindex)
+	m.Get("", cxindex)
 	m.Get("/ping", ping)
 	m.Get("/pingall", pingAll) // .. TODO: pingAll, case-sensitivity .. etc....?
 	m.Get("/ping/all", pingAll)


### PR DESCRIPTION
Mounting leaves with empty paths like ```r.Get("",func...)``` panics with index out of range errors.
Sometimes it happens even with sane paths w/ many subgroups, I'm not sure why; however, this commit fixes that.

This commit converts empty paths to single slashes, so "" becomes "/".