### PR TITLE
Use a single log line per request, very similar to Apache-style logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Chi comes equipped with an optional `middleware` package, providing:
 | Throttle    | Puts a ceiling on the number of concurrent requests.                            |
 -------------------------------------------------------------------------------------------------
 
+**NOTE:** if you are using Logger and Recoverer middlewares, Logger should precede Recoverer in order to have all panic responses logged as well.
+
 Other middlewares:
 
 * [httpcoala](https://github.com/goware/httpcoala) - request coalescer

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -23,7 +23,8 @@ func Recoverer(next chi.Handler) chi.Handler {
 		defer func() {
 			if err := recover(); err != nil {
 				reqID := GetReqID(ctx)
-				printPanic(reqID, err)
+				prefix := requestPrefix(reqID, r)
+				printPanic(prefix, reqID, err)
 				debug.PrintStack()
 				http.Error(w, http.StatusText(500), 500)
 			}
@@ -35,13 +36,10 @@ func Recoverer(next chi.Handler) chi.Handler {
 	return chi.HandlerFunc(fn)
 }
 
-func printPanic(reqID string, err interface{}) {
+func printPanic(prefix, reqID string, err interface{}) {
 	var buf bytes.Buffer
 
-	if reqID != "" {
-		cW(&buf, nYellow, "[%s] ", reqID)
-	}
 	cW(&buf, bRed, "panic: %+v", err)
 
-	log.Print(buf.String())
+	log.Print(prefix + buf.String())
 }


### PR DESCRIPTION
This also means that count of bytes written is introduced in the log line.

The choice of colors is pretty much arbitrary, so if you have better ideas please say so :blush: 