### PR TITLE
Fixes panic on HTTP method not in methodMap

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -3,6 +3,7 @@ package chi
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"golang.org/x/net/context"
 )
@@ -224,8 +225,25 @@ func (tr treeRouter) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *h
 		routePath = r.URL.Path
 	}
 
+	// Check if method is supported by chi
+	method, ok := methodMap[r.Method]
+	if !ok {
+		w.WriteHeader(405)
+
+		// Return allowed methods, as required by RFC2616 for 405 Method not allowed
+		methods := make([]string, len(methodMap))
+		i := 0
+		for m := range methodMap {
+			methods[i] = m // stil faster than append to array with capacity
+			i++
+		}
+		w.Header().Add("Allow", strings.Join(methods, ","))
+
+		w.Write([]byte(http.StatusText(405)))
+		return
+	}
 	// Find the handler in the router
-	cxh := tr[methodMap[r.Method]].Find(routePath, params)
+	cxh := tr[method].Find(routePath, params)
 	if cxh == nil {
 		w.WriteHeader(404)
 		w.Write([]byte(http.StatusText(404)))

--- a/mux.go
+++ b/mux.go
@@ -228,16 +228,15 @@ func (tr treeRouter) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *h
 	// Check if method is supported by chi
 	method, ok := methodMap[r.Method]
 	if !ok {
-		w.WriteHeader(405)
-
 		// Return allowed methods, as required by RFC2616 for 405 Method not allowed
 		methods := make([]string, len(methodMap))
 		i := 0
 		for m := range methodMap {
-			methods[i] = m // stil faster than append to array with capacity
+			methods[i] = m // still faster than append to array with capacity
 			i++
 		}
 		w.Header().Add("Allow", strings.Join(methods, ","))
+		w.WriteHeader(405)
 
 		w.Write([]byte(http.StatusText(405)))
 		return

--- a/mux_test.go
+++ b/mux_test.go
@@ -201,7 +201,7 @@ func TestMux(t *testing.T) {
 		t.Error("expecting response body: 'catchall'")
 	}
 
-	// Custom http method DIE /admin/catch-this
+	// Custom http method DIE /ping/1/woop
 	if resp := testRequest(t, ts, "DIE", "/ping/1/woop", nil); resp != "Method Not Allowed" {
 		t.Fatalf(resp)
 	}

--- a/mux_test.go
+++ b/mux_test.go
@@ -200,6 +200,11 @@ func TestMux(t *testing.T) {
 	if string(body) != "catchall" {
 		t.Error("expecting response body: 'catchall'")
 	}
+
+	// Custom http method DIE /admin/catch-this
+	if resp := testRequest(t, ts, "DIE", "/ping/1/woop", nil); resp != "Method Not Allowed" {
+		t.Fatalf(resp)
+	}
 }
 
 func TestMuxPlain(t *testing.T) {


### PR DESCRIPTION
This is just a panic fix, but IMO we should allow custom HTTP methods (HTTP is extensible) instead
of relying on a static map. methodMap should be only used for the standard methods defined in HTTP RFCs - for the `Mux.Get` short methods.