### PR TITLE
Mux ServeHTTPC supports context of generic implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.sw?
+.vscode


### PR DESCRIPTION
ServeHTTPC  method will embed a chi.Context inside an existing different implementation of context.Context