### PR TITLE
Request/Response headers debugging middleware

### DIFF
--- a/middleware/debug.go
+++ b/middleware/debug.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/pressly/chi"
+	"golang.org/x/net/context"
+)
+
+func LogRequestHeaders(next chi.Handler) chi.Handler {
+	fn := func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		data, _ := json.MarshalIndent(r.Header, "", "  ")
+		log.Printf("Request headers:\n%s\n", data)
+
+		next.ServeHTTPC(ctx, w, r)
+	}
+
+	return chi.HandlerFunc(fn)
+}
+
+func LogResponseHeaders(next chi.Handler) chi.Handler {
+	fn := func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTPC(ctx, w, r)
+
+		data, _ := json.MarshalIndent(w.Header(), "", "  ")
+		log.Printf("Response headers:\n%s\n", data)
+	}
+
+	return chi.HandlerFunc(fn)
+}


### PR DESCRIPTION
Helpful middleware for debugging Request and Response Headers.

I found myself re-implementing similar feature multiple times already. Note that `httputil.DumpRequest()` (and similar funcs) are not easily pluggable to complex routes and their output is not that readable.

We can discuss if we want this in middleware pkg, or in debug pkg or something. Or if we want it at all?
If we do, I can add `LogRequestBody` and `LogResponseBody` too.