### PR TITLE
Support mux.ServeHTTPC custom context

### DIFF
--- a/chi.go
+++ b/chi.go
@@ -9,8 +9,8 @@ import (
 // NewRouter returns a new Mux object that implements the Router interface.
 // It accepts an optional parent context.Context argument used by all
 // request contexts useful for signaling a server shutdown.
-func NewRouter(parent ...context.Context) *Mux {
-	return NewMux(parent...)
+func NewRouter() *Mux {
+	return NewMux()
 }
 
 // A Router consisting of the core routing methods used by chi's Mux.

--- a/context.go
+++ b/context.go
@@ -22,10 +22,10 @@ type Context struct {
 	RoutePath string
 }
 
-// neContext returns a new routing context object.
-func newContext(parent context.Context) *Context {
+// NewContext returns a new routing context object.
+func NewContext() *Context {
 	rctx := &Context{}
-	ctx := context.WithValue(parent, routeCtxKey, rctx)
+	ctx := context.WithValue(context.Background(), routeCtxKey, rctx)
 	rctx.Context = ctx
 	return rctx
 }

--- a/mux.go
+++ b/mux.go
@@ -19,9 +19,6 @@ var _ Router = &Mux{}
 // for writing large REST API services that break a handler into many smaller
 // parts composed of middlewares and end handlers.
 type Mux struct {
-	// A parent root context for any request that is usually a server context
-	parentCtx context.Context
-
 	// The middleware stack, supporting..
 	// func(http.Handler) http.Handler and func(chi.Handler) chi.Handler
 	middlewares []interface{}
@@ -70,17 +67,11 @@ var methodMap = map[string]methodTyp{
 }
 
 // NewMux returns a new Mux object with an optional parent context.
-func NewMux(parent ...context.Context) *Mux {
-	pctx := context.Background()
-	if len(parent) > 0 {
-		pctx = parent[0]
-	}
-
-	mux := &Mux{parentCtx: pctx, router: newTreeRouter(), handler: nil}
+func NewMux() *Mux {
+	mux := &Mux{router: newTreeRouter(), handler: nil}
 	mux.pool.New = func() interface{} {
-		return newContext(pctx)
+		return NewContext()
 	}
-
 	return mux
 }
 
@@ -264,15 +255,31 @@ func (mx *Mux) Mount(path string, handlers ...interface{}) {
 // Mux interoperable with the standard library. It uses a sync.Pool to get and
 // reuse routing contexts for each request.
 func (mx *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := mx.pool.Get().(*Context)
-	mx.ServeHTTPC(ctx, w, r)
-	ctx.reset()
-	mx.pool.Put(ctx)
+	mx.ServeHTTPC(nil, w, r)
 }
 
 // ServeHTTPC is chi's Handler method that adds a context.Context argument to the
 // standard ServeHTTP handler function.
 func (mx *Mux) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	if ctx == nil {
+		rctx := mx.pool.Get().(*Context)
+		mx.handler.ServeHTTPC(rctx, w, r)
+		rctx.reset()
+		mx.pool.Put(rctx)
+		return
+	}
+
+	if rctx, ok := ctx.(*Context); !ok {
+		if rctx, ok = ctx.Value(routeCtxKey).(*Context); !ok {
+			rctx = mx.pool.Get().(*Context)
+			ctx = context.WithValue(ctx, routeCtxKey, rctx)
+			mx.handler.ServeHTTPC(ctx, w, r)
+			rctx.reset()
+			mx.pool.Put(rctx)
+			return
+		}
+	}
+
 	mx.handler.ServeHTTPC(ctx, w, r)
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -142,7 +142,7 @@ func TestTree(t *testing.T) {
 
 	for i, tt := range tests {
 		// params := make(map[string]string, 0)
-		rctx := newContext(context.Background())
+		rctx := NewContext()
 		handler := tr.Find(rctx, tt.r) //, params)
 		params := urlParams(rctx)
 		if fmt.Sprintf("%v", tt.h) != fmt.Sprintf("%v", handler) {
@@ -197,7 +197,7 @@ func BenchmarkTreeGet(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// params := map[string]string{}
-		mctx := newContext(context.Background())
+		mctx := NewContext()
 		tr.Find(mctx, "/ping/123/456")
 		// tr.Find("/pingggg", params)
 	}


### PR DESCRIPTION
fixes issue #37 

Details:
* Removed parentCtx from the Mux. The initial idea here was that the server-level context could be used as the parent for each request context, and it did do that, unfortunately it would be incorrect to close the server context and then signal to each request context to cancel as well. In chi v2.0 I have a different idea for how to handle server shutdowns, but this isn't the correct way.
* Rename/export newContext() method as NewContext(). Its useful for others if their writing tests.
* Moved all logic for generating a routeContext to the Mux.ServeHTTPC() method. The method calls are result of:
   1. ctx is passed by Mux.ServeHTTP() request
   2. ctx is passed by a chi subrouter
   3. ctx is passed with a custom parent context
