### PR TITLE
Context pooling is causing server panics

### DIFF
--- a/context.go
+++ b/context.go
@@ -37,15 +37,6 @@ func NewRouteContext() *Context {
 	return &Context{}
 }
 
-// reset a routing context to its initial state.
-func (x *Context) reset() {
-	x.parent = nil
-	x.Params = x.Params[:0]
-	x.RoutePath = ""
-	x.RoutePattern = ""
-	x.RoutePatterns = x.RoutePatterns[:0]
-}
-
 func (ctx *Context) Deadline() (deadline time.Time, ok bool) {
 	return ctx.parent.Deadline()
 }


### PR DESCRIPTION
We deployed go 1.7 + chi 2 yesterday and noticed occasionally a machine would go out of service with:
```
panic: context: internal error: missing cancel error

goroutine 156 [running]:
panic(0x675540, 0xc42012f880)
	/opt/go-17/src/runtime/panic.go:500 +0x1a1
context.(*cancelCtx).cancel(0xc42001a600, 0x476900, 0x0, 0x0)
	/opt/go-17/src/context/context.go:339 +0x24b
context.(*timerCtx).cancel(0xc42001a600, 0x0, 0x0, 0x0)
	/opt/go-17/src/context/context.go:413 +0x4a
context.propagateCancel.func1(0x803660, 0xc42001a540, 0x800f20, 0xc42001a600)
	/opt/go-17/src/context/context.go:264 +0x128
created by context.propagateCancel
	/opt/go-17/src/context/context.go:267 +0x1dc
```

It appears chi is pooling custom context objects, but these objects can live longer than a request due to this snippet in context.go
````
func propagateCancel(parent Context, child canceler) {
	if parent.Done() == nil {
		return // parent is never canceled
	}
	if p, ok := parentCancelCtx(parent); ok {
		p.mu.Lock()
		if p.err != nil {
			// parent has already been canceled
			child.cancel(false, p.err)
		} else {
			if p.children == nil {
				p.children = make(map[canceler]bool)
			}
			p.children[child] = true
		}
		p.mu.Unlock()
	} else {
		go func() {   /// <<<<<<< This may live longer than a request, and the parent.Err() may have been reset between Done() and Err().
			select {
			case <-parent.Done():
				child.cancel(false, parent.Err())
			case <-child.Done():
			}
		}()
	}
}
```

This PR includes a failing test and the removal of the pooling.

It appears that this wouldn't be a problem if chi didn't create its own type of context object and just used Values, perhaps that would be a better approach? It would then fall into the `parentCancelCtx` part of `propagateCancel` and save a goroutine.