### PR TITLE
Use HTTP status constants instead of integers

### DIFF
--- a/_examples/rest/main.go
+++ b/_examples/rest/main.go
@@ -120,8 +120,8 @@ func ArticleCtx(next http.Handler) http.Handler {
 		articleID := chi.URLParam(r, "articleID")
 		article, err := dbGetArticle(articleID)
 		if err != nil {
-			render.Status(r, 404)
-			render.JSON(w, r, http.StatusText(404))
+			render.Status(r, http.StatusNotFound)
+			render.JSON(w, r, http.StatusText(http.StatusNotFound))
 			return
 		}
 		ctx := context.WithValue(r.Context(), "article", article)
@@ -223,7 +223,7 @@ func AdminOnly(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		isAdmin, ok := r.Context().Value("acl.admin").(bool)
 		if !ok || !isAdmin {
-			http.Error(w, http.StatusText(403), 403)
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -23,7 +23,7 @@ func Recoverer(next http.Handler) http.Handler {
 				prefix := requestPrefix(reqID, r)
 				printPanic(prefix, reqID, err)
 				debug.PrintStack()
-				http.Error(w, http.StatusText(500), 500)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			}
 		}()
 


### PR DESCRIPTION
I changed the HTTP status codes from integer to constants to follow the standards on other parts of the code