### PR TITLE
Update not found handlers recursively fix #110

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -163,6 +163,7 @@ func (mx *Mux) Trace(pattern string, handlerFn http.HandlerFunc) {
 // not be found. The default 404 handler is `http.NotFound`.
 func (mx *Mux) NotFound(handlerFn http.HandlerFunc) {
 	mx.notFoundHandler = handlerFn
+	updateSubroutesWithNotFound(mx, handlerFn)
 }
 
 // MethodNotAllowed sets a custom http.HandlerFunc for routing paths where the
@@ -379,4 +380,17 @@ func (mx *Mux) routeHTTP(w http.ResponseWriter, r *http.Request) {
 func methodNotAllowedHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(405)
 	w.Write(nil)
+}
+
+func updateSubroutesWithNotFound(mux *Mux, handlerFn http.HandlerFunc) {
+	for _, r := range mux.tree.routes() {
+		subMux, ok := r.SubRoutes.(*Mux)
+		if !ok {
+			continue
+		}
+		if subMux.notFoundHandler == nil {
+			subMux.notFoundHandler = handlerFn
+		}
+		updateSubroutesWithNotFound(subMux, handlerFn)
+	}
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -359,6 +359,58 @@ func TestMuxNestedNotFound(t *testing.T) {
 	}
 }
 
+func TestMuxComplicatedNotFound(t *testing.T) {
+	// sub router with groups
+	sub := NewRouter()
+	sub.Route("/resource", func(r Router) {
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("private get"))
+		})
+	})
+
+	// Root router with groups
+	r := NewRouter()
+	r.Get("/auth", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("auth get"))
+	})
+	r.Route("/public", func(r Router) {
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("public get"))
+		})
+	})
+	r.Mount("/private", sub)
+	r.NotFound(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("custom not-found"))
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	// check that we didn't broke correct routes
+	if _, body := testRequest(t, ts, "GET", "/auth", nil); body != "auth get" {
+		t.Fatalf(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/public", nil); body != "public get" {
+		t.Fatalf(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/private/resource", nil); body != "private get" {
+		t.Fatalf(body)
+	}
+	// check custom not-found on all levels
+	if _, body := testRequest(t, ts, "GET", "/nope", nil); body != "custom not-found" {
+		t.Fatalf(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/public/nope", nil); body != "custom not-found" {
+		t.Fatalf(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/private/nope", nil); body != "custom not-found" {
+		t.Fatalf(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/private/resource/nope", nil); body != "custom not-found" {
+		t.Fatalf(body)
+	}
+}
+
 func TestMuxWith(t *testing.T) {
 	var cmwInit1, cmwHandler1 uint64
 	var cmwInit2, cmwHandler2 uint64


### PR DESCRIPTION
It solves 2 problems:
1. It sets not-found custom handler for all subtrees if they don't have custom handler already
2. You can define custom not-found handler before or after any mounts.