### PR TITLE
add request time in default logger

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -16,10 +16,10 @@ var (
 )
 
 // Logger is a middleware that logs the start and end of each request, along
-// with some useful data about what was requested, what the response status was,
-// and how long it took to return. When standard output is a TTY, Logger will
-// print in color, otherwise it will print in black and white.
-//
+// with some useful data about what was requested, when the request in, what
+// the response status was, and how long it took to return. When standard
+// output is a TTY, Logger will print in color, otherwise it will print in
+// black and white.
 // Logger prints a request ID if one is provided.
 func Logger(next http.Handler) http.Handler {
 	return defaultLogger(next)
@@ -72,6 +72,9 @@ func (l *defaultLogFormatter) NewLogEntry(r *http.Request) LogEntry {
 		request:             r,
 		buf:                 &bytes.Buffer{},
 	}
+
+	currentTime := time.Now().Format("2006/01/02 - 15:04:05")
+	entry.buf.WriteString(currentTime + " ")
 
 	reqID := GetReqID(r.Context())
 	if reqID != "" {

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -73,8 +73,8 @@ func (l *defaultLogFormatter) NewLogEntry(r *http.Request) LogEntry {
 		buf:                 &bytes.Buffer{},
 	}
 
-	currentTime := time.Now().Format("2006/01/02 - 15:04:05")
-	entry.buf.WriteString(currentTime + " ")
+	currentTime := time.Now().Format("2006/01/02 - 15:04:05 ")
+	entry.buf.WriteString(currentTime)
 
 	reqID := GetReqID(r.Context())
 	if reqID != "" {


### PR DESCRIPTION
I think it will be very useful if the default logger recored the request time, or the log cannot tell us anything about time.

before this changed, the default logger output looks like:

```
"GET http://127.0.0.1:3000/ HTTP/1.1" from 127.0.0.1:53322 - 200 7B in 12.29µs
```

now it will be:
```
2016/12/15 - 11:40:12 "GET http://127.0.0.1:3000/ HTTP/1.1" from 127.0.0.1:53322 - 200 7B in 12.29µs
```