### PR TITLE
Remove the content-length header from compressed responses

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -133,6 +133,8 @@ func (w *maybeCompressResponseWriter) WriteHeader(code int) {
 	if w.ResponseWriter.Header().Get("Content-Encoding") != "" {
 		return
 	}
+	// The content-length after compression is unknown
+	w.ResponseWriter.Header().Del("Content-Length")
 
 	// Parse the first part of the Content-Type response header.
 	contentType := ""


### PR DESCRIPTION
We can't allow this header through as it should be set to the length of the compressed body. We don't know that length, so we just delete it. Sending the incorrect content-length didn't seem to cause issues when requesting the server directly, but the Amazon load balancer really did not appreciate the incorrect headers (gave me SPDY errors in Chrome)