### PR TITLE
OPTIMIZE: Change ServerBaseContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -111,6 +111,7 @@ func (ps *params) Del(key string) string {
 func ServerBaseContext(h http.Handler, baseCtx context.Context) http.Handler {
 	fn := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		baseCtx := baseCtx
 
 		// Copy over default net/http server context keys
 		if v, ok := ctx.Value(http.ServerContextKey).(*http.Server); ok {


### PR DESCRIPTION
Upon transitioning our production services to ServerBaseContext, we saw a serious regression with performance. It wasn't obvious, but I was able to narrow it down to a mysterious solution. Here's a gist of a reproducible benchmark:

https://gist.github.com/cyx/8730ab8d31996711110d9979d1715f98

Long story short, it seems if we create a copy of the base context, then we don't see this performance regression.

I'm open to discuss this some more -- and I've already picked the brains of other Go programmers in our company to see what they think. Logic dictates the copy doesn't do anything, but empirical data shows it does.

Thought this will be useful for others.