### PR TITLE
Add dummy CloseNotify for backwards compatibility.

### DIFF
--- a/middleware/closenotify17.go
+++ b/middleware/closenotify17.go
@@ -11,8 +11,8 @@ import (
 // connection has gone away. It can be used to cancel long operations
 // on the server when the client disconnects before the response is ready.
 //
-// Note: this behaviour is standard in Go 1.8+ so the middleware is no
-// longer provided and exists just for backwards compatability.
+// Note: this behaviour is standard in Go 1.8+, so the middleware does nothing
+// on 1.8+ and exists just for backwards compatibility.
 func CloseNotify(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		cn, ok := w.(http.CloseNotifier)

--- a/middleware/closenotify18.go
+++ b/middleware/closenotify18.go
@@ -1,0 +1,17 @@
+// +build go1.8
+
+package middleware
+
+import (
+	"net/http"
+)
+
+// CloseNotify is a middleware that cancels ctx when the underlying
+// connection has gone away. It can be used to cancel long operations
+// on the server when the client disconnects before the response is ready.
+//
+// Note: this behaviour is standard in Go 1.8+, so the middleware does nothing
+// on 1.8+ and exists just for backwards compatibility.
+func CloseNotify(next http.Handler) http.Handler {
+    return next
+}


### PR DESCRIPTION
This makes code that uses middleware.CloseNotify compile on 1.8.

Also clarify in the documentation that the middleware
only does nothing on Go 1.8+.