### PR TITLE
GetContentType ignore charset

### DIFF
--- a/render/content_type.go
+++ b/render/content_type.go
@@ -25,7 +25,8 @@ const (
 )
 
 func GetContentType(s string) ContentType {
-	switch s {
+	parts = strings.Split(s, ";")
+	switch parts[0] {
 	case "text/plain":
 		return ContentTypePlainText
 	case "text/html", "application/xhtml+xml":

--- a/render/content_type.go
+++ b/render/content_type.go
@@ -25,7 +25,7 @@ const (
 )
 
 func GetContentType(s string) ContentType {
-	parts = strings.Split(s, ";")
+	parts := strings.Split(s, ";")
 	switch parts[0] {
 	case "text/plain":
 		return ContentTypePlainText


### PR DESCRIPTION
Splits the Content-Type after `;` to correctly parse headers like `Content-Type: application/json; charset=utf-8`