### PR TITLE
Return interface instead of struct implementation

### DIFF
--- a/chi.go
+++ b/chi.go
@@ -32,7 +32,7 @@ package chi
 import "net/http"
 
 // NewRouter returns a new Mux object that implements the Router interface.
-func NewRouter() *Mux {
+func NewRouter() Router {
 	return NewMux()
 }
 


### PR DESCRIPTION
`Mux` satisfies the `Router` interface and returning interfaces is preferred whenever possible to comply to S.O.L.I.D. principles.