### PR TITLE
Add trace handler to the profiler

### DIFF
--- a/middleware/profiler.go
+++ b/middleware/profiler.go
@@ -33,6 +33,7 @@ func Profiler() http.Handler {
 	r.HandleFunc("/pprof/cmdline", pprof.Cmdline)
 	r.HandleFunc("/pprof/profile", pprof.Profile)
 	r.HandleFunc("/pprof/symbol", pprof.Symbol)
+	r.HandleFunc("/pprof/trace", pprof.Trace)
 	r.Handle("/pprof/block", pprof.Handler("block"))
 	r.Handle("/pprof/heap", pprof.Handler("heap"))
 	r.Handle("/pprof/goroutine", pprof.Handler("goroutine"))


### PR DESCRIPTION
This MR adds a handler to profiler, that enables downloading execution traces f.e. with:
`wget http://host:PORT/debug/pprof/trace?seconds=5`

Since chi relies on std context (>=go1.7), this addition should be safe (trace handler was added somewhere around 1.5 I think, but again this is not an issue here)