### PR TITLE
middleware/logger: use time.Since instead of Sub

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -35,8 +35,7 @@ func RequestLogger(f LogFormatter) func(next http.Handler) http.Handler {
 
 			t1 := time.Now()
 			defer func() {
-				t2 := time.Now()
-				entry.Write(ww.Status(), ww.BytesWritten(), t2.Sub(t1))
+				entry.Write(ww.Status(), ww.BytesWritten(), time.Since(t1))
 			}()
 
 			next.ServeHTTP(ww, WithLogEntry(r, entry))


### PR DESCRIPTION
Noticed this while skimming through the source code. I did a search and look like this is the only usage.